### PR TITLE
Fix versioncmp Debian 8

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -7,7 +7,7 @@ class mariadb::repo::apt {
 
   $version = $mariadb::repo::repo_version
   $os      = $mariadb::repo::os
-  if (($::operatingsystem == 'Debian') and (versioncmp($::operatingsystemrelease, '8.0') >= 0)) or
+  if (($::operatingsystem == 'Debian') and (versioncmp($::operatingsystemrelease, '9.0') >= 0)) or
   (($::operatingsystem == 'Ubuntu') and (versioncmp($::operatingsystemrelease, '16.04') >= 0)) {
     $key = {
       'id' => '177F4010FE56CA3336300305F1656F24C74CD1D8',


### PR DESCRIPTION
De versioncmp function was being called with wrong input values. The operatingsystemrelease was compared against 8.0. Therefore, the key for Debian 9 was being applied. By changing the value from 8.0 to 9.0 the issue is resolved. This is also tested on both Debian 8 and 9.