### PR TITLE
Use puppet 4 compatible functions

### DIFF
--- a/manifests/backup/mysqldump.pp
+++ b/manifests/backup/mysqldump.pp
@@ -47,7 +47,7 @@ class mariadb::backup::mysqldump (
 
   mysql_user { "${backupuser}@localhost":
     ensure        => $ensure,
-    password_hash => mysql_password($backuppassword),
+    password_hash => mysql::password($backuppassword),
     require       => Class['mysql::server::root_password'],
   }
 

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -20,7 +20,7 @@ class mariadb::client (
   $override_options    = {},
 ) inherits mariadb::params {
 
-  $options = mysql_deepmerge($mariadb::params::client_default_options, $override_options)
+  $options = mysql::deepmerge($mariadb::params::client_default_options, $override_options)
 
   if $manage_repo {
     class { '::mariadb::repo':

--- a/manifests/cluster.pp
+++ b/manifests/cluster.pp
@@ -81,8 +81,8 @@ class mariadb::cluster (
   $databases                    = {},
 ) inherits mariadb::params {
 
-  $cluster_options = mysql_deepmerge($mariadb::params::cluster_default_options, $override_options)
-  $galera_options  = mysql_deepmerge($mariadb::params::galera_default_options, $galera_override_options)
+  $cluster_options = mysql::deepmerge($mariadb::params::cluster_default_options, $override_options)
+  $galera_options  = mysql::deepmerge($mariadb::params::galera_default_options, $galera_override_options)
 
   anchor { 'mariadb::cluster::start': }
   -> class { '::mariadb::server':

--- a/manifests/cluster/galera_config.pp
+++ b/manifests/cluster/galera_config.pp
@@ -32,7 +32,7 @@ class mariadb::cluster::galera_config {
       'wsrep_sst_method'      => $mariadb::cluster::wsrep_sst_method,
     },
   }
-  $options = mysql_deepmerge($options_from_params, $mariadb::cluster::galera_options)
+  $options = mysql::deepmerge($options_from_params, $mariadb::cluster::galera_options)
   $includedir = false
 
   if $mariadb::cluster::wsrep_sst_method in ['xtrabackup', 'xtrabackup-v2'] {

--- a/manifests/cluster/wsrep_sst_user.pp
+++ b/manifests/cluster/wsrep_sst_user.pp
@@ -12,7 +12,7 @@ define mariadb::cluster::wsrep_sst_user (
 
   mysql_user { $wsrep_sst_user:
     ensure        => present,
-    password_hash => mysql_password($wsrep_sst_password),
+    password_hash => mysql::password($wsrep_sst_password),
     tls_options   => $wsrep_sst_user_tls_options,
     require       => Class['::mysql::server::root_password'],
   }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -42,7 +42,7 @@ class mariadb::server (
   $databases            = {},
 ) inherits mariadb::params {
 
-  $options = mysql_deepmerge($mariadb::params::server_default_options, $override_options)
+  $options = mysql::deepmerge($mariadb::params::server_default_options, $override_options)
 
   if $manage_repo {
     class { '::mariadb::repo':

--- a/manifests/server/mysql.pp
+++ b/manifests/server/mysql.pp
@@ -28,7 +28,7 @@ class mariadb::server::mysql (
   class { '::mysql::server':
     config_file             => $mariadb::server::config_file,
     includedir              => $mariadb::server::includedir,
-    override_options        => mysql_deepmerge($auth_pam_options, $options),
+    override_options        => mysql::deepmerge($auth_pam_options, $options),
     package_ensure          => installed,
     package_name            => $package_name,
     remove_default_accounts => true,

--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/mysql",
-      "version_requirement": ">= 3.10.0 < 6.0.0"
+      "version_requirement": ">= 6.0.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
In minor release Puppet 5.5.7 they introduced a
change [1] that caused all Puppet 3 function to
pretty much stop working properly.

This causes issues like [2] for Puppet >= 5.5.7

The puppetlabs-mysql module has support for the
puppet 4+ compatible functions since it's 6.0.0
release, bug was tracked in [3].

The fix in the module is here [4].

[1] https://tickets.puppetlabs.com/browse/PUP-9137
[2] https://gist.github.com/tobias-urdin/491e97da6585def720fc4f830e212f30
[3] https://tickets.puppetlabs.com/browse/PUP-9270
[4] https://github.com/puppetlabs/puppetlabs-mysql/pull/1044