### PR TITLE
Porting to use the new mysql::deepmerge function

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -20,7 +20,7 @@ class mariadb::client (
   $override_options    = {},
 ) inherits mariadb::params {
 
-  $options = mysql_deepmerge($mariadb::params::client_default_options, $override_options)
+  $options = mysql::deepmerge($mariadb::params::client_default_options, $override_options)
 
   if $manage_repo {
     class { '::mariadb::repo':

--- a/manifests/cluster.pp
+++ b/manifests/cluster.pp
@@ -81,8 +81,8 @@ class mariadb::cluster (
   $databases                    = {},
 ) inherits mariadb::params {
 
-  $cluster_options = mysql_deepmerge($mariadb::params::cluster_default_options, $override_options)
-  $galera_options  = mysql_deepmerge($mariadb::params::galera_default_options, $galera_override_options)
+  $cluster_options = mysql::deepmerge($mariadb::params::cluster_default_options, $override_options)
+  $galera_options  = mysql::deepmerge($mariadb::params::galera_default_options, $galera_override_options)
 
   anchor { 'mariadb::cluster::start': }
   -> class { '::mariadb::server':

--- a/manifests/cluster/galera_config.pp
+++ b/manifests/cluster/galera_config.pp
@@ -32,7 +32,7 @@ class mariadb::cluster::galera_config {
       'wsrep_sst_method'      => $mariadb::cluster::wsrep_sst_method,
     },
   }
-  $options = mysql_deepmerge($options_from_params, $mariadb::cluster::galera_options)
+  $options = mysql::deepmerge($options_from_params, $mariadb::cluster::galera_options)
   $includedir = false
 
   if $mariadb::cluster::wsrep_sst_method in ['xtrabackup', 'xtrabackup-v2'] {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -42,7 +42,7 @@ class mariadb::server (
   $databases            = {},
 ) inherits mariadb::params {
 
-  $options = mysql_deepmerge($mariadb::params::server_default_options, $override_options)
+  $options = mysql::deepmerge($mariadb::params::server_default_options, $override_options)
 
   if $manage_repo {
     class { '::mariadb::repo':

--- a/manifests/server/mysql.pp
+++ b/manifests/server/mysql.pp
@@ -28,7 +28,7 @@ class mariadb::server::mysql (
   class { '::mysql::server':
     config_file             => $mariadb::server::config_file,
     includedir              => $mariadb::server::includedir,
-    override_options        => mysql_deepmerge($auth_pam_options, $options),
+    override_options        => mysql::deepmerge($auth_pam_options, $options),
     package_ensure          => installed,
     package_name            => $package_name,
     remove_default_accounts => true,


### PR DESCRIPTION
The mysql_deepmerge function was flawed and will crash on Puppet version
5.5.7. This changes your code to use the new version of the function,
which does not have this flaw.

See https://tickets.puppetlabs.com/browse/MODULES-8193 for more details.