### PR TITLE
fix: Make WSREP SST user's privileges customizable

### DIFF
--- a/manifests/cluster.pp
+++ b/manifests/cluster.pp
@@ -68,7 +68,8 @@ class mariadb::cluster (
   $wsrep_sst_password           = $mariadb::params::wsrep_sst_password,
   $wsrep_sst_user_tls_options   = undef,
   $wsrep_sst_user_grant_options = undef,
-  Enum['mariabackup', 'mysqldump', 'rsync', 'rsync_wan', 'xtrabackup', 'xtrabackup-v2'] $wsrep_sst_method = $mariadb::params::wsrep_sst_method, # lint:ignore:140chars
+  Array[String] $wresp_sst_user_privileges = $mariadb::params::wsrep_sst_user_privileges,
+  Mariadb::Wsrep_SST_Method $wsrep_sst_method = $mariadb::params::wsrep_sst_method,
   $root_password                = $mariadb::params::root_password,
   $override_options             = {},
   $galera_override_options      = {},
@@ -81,7 +82,6 @@ class mariadb::cluster (
   $grants                       = {},
   $databases                    = {},
 ) inherits mariadb::params {
-
   $cluster_options = mysql::normalise_and_deepmerge($mariadb::params::cluster_default_options, $override_options)
   $galera_options  = mysql::normalise_and_deepmerge($mariadb::params::galera_default_options, $galera_override_options)
 

--- a/manifests/cluster/auth.pp
+++ b/manifests/cluster/auth.pp
@@ -4,7 +4,6 @@
 #
 
 class mariadb::cluster::auth {
-
   if $mariadb::cluster::wsrep_sst_password != 'UNSET' {
     $wsrep_sst_peers = any2array($mariadb::cluster::wsrep_sst_user_peers)
     $wsrep_sst_users = prefix($wsrep_sst_peers, "${mariadb::cluster::wsrep_sst_user}@")
@@ -13,6 +12,7 @@ class mariadb::cluster::auth {
       wsrep_sst_password           => $mariadb::cluster::wsrep_sst_password,
       wsrep_sst_user_tls_options   => $mariadb::cluster::wsrep_sst_user_tls_options,
       wsrep_sst_user_grant_options => $mariadb::cluster::wsrep_sst_user_grant_options,
+      wsrep_sst_user_privileges    => $mariadb::cluster::wsrep_sst_user_privileges,
     }
   }
 }

--- a/manifests/cluster/wsrep_sst_user.pp
+++ b/manifests/cluster/wsrep_sst_user.pp
@@ -1,15 +1,25 @@
-# wsrep_sst_user.pp
-# Manage one wsrep_sst_auth user.
+# @summary Manage one wsrep_sst_auth user
+# 
 # This user is used to sync between cluster nodes and thus needs root like access to everything.
 #
-
+# @param wsrep_sst_password
+# @param wsrep_sst_user
+# @param wsrep_sst_user_tls_options
+# @param wsrep_sst_user_grant_options
+# @param wsrep_sst_user_privileges
+#
 define mariadb::cluster::wsrep_sst_user (
-  $wsrep_sst_password,
-  $wsrep_sst_user               = $name,
-  $wsrep_sst_user_tls_options   = undef,
-  $wsrep_sst_user_grant_options = undef,
+  String $wsrep_sst_password,
+  String $wsrep_sst_user                      = $name,
+  Array[String] $wsrep_sst_user_tls_options   = undef,
+  Array[String] $wsrep_sst_user_grant_options = undef,
+  Array[String] $wsrep_sst_user_privileges    = [
+    'RELOAD',
+    'PROCESS',
+    'LOCK TABLES',
+    'BINLOG MONITOR',
+  ],
 ) {
-
   mysql_user { $wsrep_sst_user:
     ensure        => present,
     password_hash => mysql::password($wsrep_sst_password),
@@ -21,7 +31,7 @@ define mariadb::cluster::wsrep_sst_user (
     ensure     => present,
     user       => $wsrep_sst_user,
     table      => '*.*',
-    privileges => ['ALL'],
+    privileges => $wsrep_sst_user_privileges,
     options    => $wsrep_sst_user_grant_options,
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,7 +1,6 @@
 # params.pp
 # Set up MariaDB Cluster parameters defaults etc.
 #
-
 class mariadb::params {
   include 'mysql::params'
 
@@ -20,15 +19,21 @@ class mariadb::params {
   }
 
   # wsrep patch config
-  $wsrep_cluster_address = undef
-  $wsrep_cluster_peers   = undef
-  $wsrep_cluster_port    = '4567'
-  $wsrep_cluster_name    = undef
-  $wsrep_sst_user        = 'wsrep_sst'
-  $wsrep_sst_user_peers  = '%'
-  $wsrep_sst_password    = 'UNSET' # lint:ignore:security_password_in_code
-  $wsrep_sst_method      = 'mysqldump'
-  $root_password         = 'UNSET' # lint:ignore:security_password_in_code
+  $wsrep_cluster_address     = undef
+  $wsrep_cluster_peers       = undef
+  $wsrep_cluster_port        = '4567'
+  $wsrep_cluster_name        = undef
+  $wsrep_sst_user            = 'wsrep_sst'
+  $wsrep_sst_user_peers      = '%'
+  $wsrep_sst_password        = 'UNSET' # lint:ignore:security_password_in_code
+  $wsrep_sst_user_privileges = [
+    'RELOAD',
+    'PROCESS',
+    'LOCK TABLES',
+    'BINLOG MONITOR',
+  ]
+  $wsrep_sst_method          = 'mysqldump'
+  $root_password             = 'UNSET' # lint:ignore:security_password_in_code
 
   if ($::osfamily == 'RedHat') and (versioncmp($::operatingsystemrelease, '6.0') >= 0) {
     # client.pp

--- a/manifests/types/wsrep_sst_method.pp
+++ b/manifests/types/wsrep_sst_method.pp
@@ -1,0 +1,8 @@
+type Mariadb::Wsrep_SST_Method = Enum[
+  'mariabackup',
+  'mysqldump',
+  'rsync',
+  'rsync_wan',
+  'xtrabackup',
+  'xtrabackup-v2'
+]

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "edestecd-mariadb",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "author": "Chris Edester",
   "summary": "Puppet Module for managing MariaDB",
   "license": "GPL-3.0+",


### PR DESCRIPTION
Could be great to be able to customise privileges that we give to WSREP SST user (See MariaDB 10.5 privilege changes)