### PR TITLE
Bump up the repository version to 10.10 (second-newest available).

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,7 @@ class mariadb::params {
   $manage_user             = false
   $manage_timezone         = false
   $manage_repo             = true
-  $repo_version            = '10.1'
+  $repo_version            = '10.10'
   $auth_pam                = true
   $auth_pam_plugin         = 'auth_pam.so'
   $remove_default_accounts = true


### PR DESCRIPTION
Although 10.10.1 is the bleeding edge at the time of this PR, I figured 10.10 was safe to use.