### PR TITLE
fix(ensure): use enum

### DIFF
--- a/manifests/client/mysql.pp
+++ b/manifests/client/mysql.pp
@@ -7,17 +7,17 @@ class mariadb::client::mysql (
 ){
 
   class { 'mysql::client':
-    package_ensure => installed,
+    package_ensure => present,
     package_name   => $mariadb::params::client_package_name,
   }
 
   if $dev {
     class { 'mysql::bindings':
       client_dev                => true,
-      client_dev_package_ensure => installed,
+      client_dev_package_ensure => present,
       client_dev_package_name   => $mariadb::params::devel_package_name,
       daemon_dev                => $mariadb::params::shared_package_name,
-      daemon_dev_package_ensure => installed,
+      daemon_dev_package_ensure => present,
       daemon_dev_package_name   => $mariadb::params::shared_package_name,
     }
 

--- a/manifests/client/mysql.pp
+++ b/manifests/client/mysql.pp
@@ -16,7 +16,7 @@ class mariadb::client::mysql (
       client_dev                => true,
       client_dev_package_ensure => present,
       client_dev_package_name   => $mariadb::params::devel_package_name,
-      daemon_dev                => $mariadb::params::shared_package_name,
+      daemon_dev                => true,
       daemon_dev_package_ensure => present,
       daemon_dev_package_name   => $mariadb::params::shared_package_name,
     }

--- a/manifests/server/mysql.pp
+++ b/manifests/server/mysql.pp
@@ -29,7 +29,7 @@ class mariadb::server::mysql (
     config_file             => $mariadb::server::config_file,
     includedir              => $mariadb::server::includedir,
     override_options        => mysql::normalise_and_deepmerge($auth_pam_options, $options),
-    package_ensure          => installed,
+    package_ensure          => present,
     package_name            => $package_name,
     remove_default_accounts => $mariadb::server::remove_default_accounts,
     restart                 => $mariadb::server::restart,


### PR DESCRIPTION
Lastest mysql requires an enum value  of 'absent' or 'present' or a version number for these fields.

e.g. https://github.com/puppetlabs/puppetlabs-mysql/blob/main/manifests/server.pp#L27

Also requires a boolean for another bindings arg.